### PR TITLE
Remove alias_method_chain, it is deprecated in Rails 5+

### DIFF
--- a/lib/georuby-ext/georuby/ewkb_parser.rb
+++ b/lib/georuby-ext/georuby/ewkb_parser.rb
@@ -6,6 +6,7 @@ class GeoRuby::SimpleFeatures::EWKBParser
     parse_linear_ring_without_close_support 
     @factory.geometry.close!
   end
-  alias_method_chain :parse_linear_ring, :close_support
+  alias_method :parse_linear_ring_without_close_support, :parse_linear_ring
+  alias_method :parse_linear_ring, :parse_linear_ring_with_close_support
 
 end

--- a/lib/georuby-ext/georuby/linear_ring.rb
+++ b/lib/georuby-ext/georuby/linear_ring.rb
@@ -4,12 +4,14 @@ class GeoRuby::SimpleFeatures::LinearRing
     def from_points_with_close_support(*arguments)
       from_points_without_close_support(*arguments).close!
     end
-    alias_method_chain :from_points, :close_support
+    alias_method :from_points_without_close_support, :from_points
+    alias_method :from_points, :from_points_with_close_support
 
     def from_coordinates_with_close_support(*arguments)
       from_coordinates_without_close_support(*arguments).close!
     end
-    alias_method_chain :from_coordinates, :close_support
+    alias_method :from_coordinates_without_close_support, :from_coordinates
+    alias_method :from_coordinates, :from_coordinates_with_close_support
   end
 
   def to_rgeo

--- a/lib/georuby-ext/georuby/point.rb
+++ b/lib/georuby-ext/georuby/point.rb
@@ -39,7 +39,8 @@ class GeoRuby::SimpleFeatures::Point
   def spherical_distance_with_srid_support(other)
     to_wgs84.spherical_distance_without_srid_support(other.to_wgs84)
   end
-  alias_method_chain :spherical_distance, :srid_support
+  alias_method :spherical_distance_without_srid_support, :spherical_distance
+  alias_method :spherical_distance, :spherical_distance_with_srid_support
 
   def endpoint(heading, distance, options={})
     Endpointer.new(self, heading, distance, options).arrival


### PR DESCRIPTION
`alias_method_chain` was deprecated then removed from Rails 5.2. This PR just removes the syntactic sugar of `alias_method_chain`.